### PR TITLE
Feature/us 011 continious deployment to azure continuous

### DIFF
--- a/.github/workflows/deploy-database.yaml
+++ b/.github/workflows/deploy-database.yaml
@@ -3,7 +3,6 @@ name: Deploy SQL to Azure
 on:
   push:
     branches:
-      - '**'  # Temporarily allow all branches — use 'main' later
       - main
   workflow_dispatch:  # Allow manual trigger from GitHub Actions UI
 

--- a/.github/workflows/deploy-database.yaml
+++ b/.github/workflows/deploy-database.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-sql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-database.yaml
+++ b/.github/workflows/deploy-database.yaml
@@ -1,4 +1,3 @@
-#
 name: Deploy SQL to Azure
 
 on:

--- a/.github/workflows/deploy-database.yaml
+++ b/.github/workflows/deploy-database.yaml
@@ -1,0 +1,43 @@
+name: Deploy SQL to Azure
+
+on:
+  push:
+    branches:
+      - '**'  # Temporarily allow all branches — use 'main' later
+      - main
+  workflow_dispatch:  # Allow manual trigger from GitHub Actions UI
+
+jobs:
+  deploy-sql:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install SQLCMD tools
+        run: |
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+          sudo apt-add-repository "$(curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list)"
+          sudo apt-get update
+          sudo apt-get install -y mssql-tools unixodbc-dev
+          echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+          source ~/.bashrc
+
+      - name: Run all .sql files
+        env:
+          AZURE_SQL_SERVER: ${{ secrets.AZURE_SQL_SERVER }}
+          AZURE_SQL_USER: ${{ secrets.AZURE_SQL_USER }}
+          AZURE_SQL_PASSWORD: ${{ secrets.AZURE_SQL_PASSWORD }}
+          AZURE_SQL_DB: ${{ secrets.AZURE_SQL_DB }}
+        run: |
+          for script in scripts/sql/*.sql; do
+            if [[ "$(basename "$script")" == "init.sql" ]]; then
+              echo "Skipping init.sql in production: $script"
+              continue
+            fi
+
+            echo "Running: $script"
+            /opt/mssql-tools/bin/sqlcmd -S "$AZURE_SQL_SERVER" -U "$AZURE_SQL_USER" -P "$AZURE_SQL_PASSWORD" -d "$AZURE_SQL_DB" -i "$script" -C
+          done
+

--- a/.github/workflows/deploy-database.yaml
+++ b/.github/workflows/deploy-database.yaml
@@ -1,3 +1,4 @@
+#
 name: Deploy SQL to Azure
 
 on:

--- a/scripts/sql/gps.sql
+++ b/scripts/sql/gps.sql
@@ -1,0 +1,10 @@
+IF OBJECT_ID('dbo.GpsData', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.GpsData (
+       DeviceId NVARCHAR(100),
+       Latitude FLOAT,
+       Longitude FLOAT,
+       Timestamp DATETIME
+    );
+END
+GO

--- a/scripts/sql/test.sql
+++ b/scripts/sql/test.sql
@@ -1,4 +1,8 @@
-CREATE TABLE Test (
-    id INT,
-    description VARCHAR(50)
-);
+IF OBJECT_ID('dbo.Test', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Test (
+        id INT,
+        description VARCHAR(50)
+    );
+END
+GO


### PR DESCRIPTION
Added deploy-databas.yaml that deploys the database from the branch main to azure directly reading from what exists within scripts/sql, this finishes the continious deployment, allowing us actively to begin porting routes over to main that frontend, IOT can direclty use.

- Givet att backendservern är byggd och testad lokalt
- när den kopplas till Azure
- Så ska servern vara tillgänglig via en publik eller intern endpoint
- Givet att deployment sker via CI/CD
- När pipelinen körs
- Så ska koden automatiskt laddas upp och aktivera backendservern i Azure
- Givet att miljövariabler krävs för drift
- När servern körs i Azure
- Så ska den hämta och använda dessa variabler korrekt
- Givet att anslutningen är etablerad
- När jag loggar in i Azure-portalen
- Så ska jag kunna se och hantera serverinstanser, logs och konfigurationer