### PR TITLE
Dev/swagger docs for dot net

### DIFF
--- a/GpsApp/GpsApp.csproj
+++ b/GpsApp/GpsApp.csproj
@@ -4,10 +4,16 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- used for swagger where it can display XML -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn> <!-- Optional: suppresses XML doc warnings -->
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
   </ItemGroup>
 
 </Project>
+

--- a/GpsApp/GpsApp.csproj
+++ b/GpsApp/GpsApp.csproj
@@ -7,7 +7,7 @@
 
     <!-- used for swagger where it can display XML -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1591</NoWarn> <!-- Optional: suppresses XML doc warnings -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GpsApp/Program.cs
+++ b/GpsApp/Program.cs
@@ -1,4 +1,8 @@
+using System.Reflection;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
 
 // check that its using enviroment variables
 Console.WriteLine("[DEBUG] ENV: " + builder.Environment.EnvironmentName);
@@ -25,6 +29,14 @@ builder.Services.AddSingleton<SqlGet>(sp =>
     return new SqlGet(connectionString);
 });
 
+builder.Services.AddSwaggerGen(options =>
+{
+    var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFilename);
+    Console.WriteLine("[DEBUG] XML Path: " + xmlPath); // Debug print to verify path
+    options.IncludeXmlComments(xmlPath);
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -32,6 +44,13 @@ if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error");
     app.UseHsts();
+}
+
+// starts swagger
+if (app.Environment.IsDevelopment() || app.Environment.IsStaging() || app.Environment.IsProduction())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
 app.UseHttpsRedirection();

--- a/GpsApp/controller/gpsGetController.cs
+++ b/GpsApp/controller/gpsGetController.cs
@@ -15,7 +15,9 @@ public class GpsGetController : ControllerBase
     }
 
 
-
+    /// <summary>
+    /// Returns a GPS value
+    /// </summary>
     [HttpGet]
     public async Task<IActionResult> GetGpsData([FromQuery] GpsData data)
     {

--- a/GpsApp/controller/gpsPostController.cs
+++ b/GpsApp/controller/gpsPostController.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 
+
+
 [ApiController]
 [Route("[controller]")]
 public class GpsController : ControllerBase
@@ -15,7 +17,14 @@ public class GpsController : ControllerBase
         _insertService = insertService;
     }
 
-
+    /// <summary>
+    /// Adds new GPS data.
+    /// </summary>
+    /// <param name="data">The GPS data to insert.</param>
+    /// <returns>Returns OK if inserted successfully.</returns>
+    /// <remarks>
+    /// Latitude must be between -90 and 90. Longitude between -180 and 180.
+    /// </remarks>
     [HttpPost]
     public async Task<IActionResult> PostGpsData([FromBody] GpsData data)
     {


### PR DESCRIPTION
adds swagger docs to dotnet displaying the routes visually at http://localhost:(port)/swagger/index.html
<img width="1565" height="1238" alt="Screenshot 2025-09-19 134405" src="https://github.com/user-attachments/assets/1dd3bcae-af87-4a5c-ac39-cce37c99b539" />



Display comments above HTTPGet or HTTPPost within the controllers to modify parts of what swagger displays
<img width="612" height="489" alt="Screenshot 2025-09-19 134507" src="https://github.com/user-attachments/assets/e3fca8c0-f39d-4154-9a49-a093a3340f1b" />
